### PR TITLE
Fix Zotero.Style.get for juris-m.github.io based styles

### DIFF
--- a/chrome/content/zotero/xpcom/style.js
+++ b/chrome/content/zotero/xpcom/style.js
@@ -189,8 +189,15 @@ Zotero.Styles = new function() {
 		// TODO: With asynchronous style loading, move renamedStyles call back here
 		
 		if(!skipMappings) {
-			var prefix = "http://www.zotero.org/styles/";
+			var prefix = "http://juris-m.github.io/styles/";
 			var shortName = id.replace(prefix, "");
+			if(_renamedStyles.hasOwnProperty(shortName) && _styles[prefix + _renamedStyles[shortName]]) {
+				let newID = prefix + _renamedStyles[shortName];
+				Zotero.debug("Mapping " + id + " to " + newID);
+				return _styles[newID];
+			}
+			prefix = "http://www.zotero.org/styles/";
+			shortName = id.replace(prefix, "");
 			if(_renamedStyles.hasOwnProperty(shortName) && _styles[prefix + _renamedStyles[shortName]]) {
 				let newID = prefix + _renamedStyles[shortName];
 				Zotero.debug("Mapping " + id + " to " + newID);


### PR DESCRIPTION
It did not know about the "http://juris-m.github.io/style/" prefix yet.
