### PR TITLE
Fix permission error for deployer submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,5 +20,5 @@
 	url = https://github.com/domenic/chai-as-promised.git
 [submodule "deployer"]
 	path = deployer
-	url = git@github.com:Juris-M/deployer.git
+	url = https://github.com/Juris-M/deployer.git
 


### PR DESCRIPTION
The ssh url gave me a permission denied error. In github desktop for example: 

> Authentication failed. You may not have permission to access the repository or the repository may have been archived. Open options and verify that you're signed in with an account that has permission to access this repository.

Changing to https fixes this. Same change is required in zotero-standalone-build.