### PR TITLE
Fixed _handleRelated for web translators

### DIFF
--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -985,20 +985,21 @@ Zotero.Translate.ItemSaver.prototype = {
 	
 	"_handleRelated":function(item, newItem) {
 		// add to ID map
-		if(item.itemID || item.id) {
-			this._IDMap[item.itemID || item.id] = newItem.id;
-		}
+		if (item.itemID || item.id) {
+			this._IDMap[item.itemID || item.id] = newItem;
+		  }
 
-		// // add see alsos
-		// if(item.seeAlso) {
-		// 	for(var i=0; i<item.seeAlso.length; i++) {
-		// 		var seeAlso = item.seeAlso[i];
-		// 		if(this._IDMap[seeAlso]) {
-		// 			newItem.addRelatedItem(this._IDMap[seeAlso]);
-		// 		}
-		// 	}
-		// 	newItem.save();
-		// }
+		  // add see alsos
+		  if(item.seeAlso) {
+			for(related in item.seeAlso) {
+			  if(this._IDMap[related]) {
+				newItem.addRelatedItem(this._IDMap[related]);
+				this._IDMap[related].addRelatedItem(newItem);
+				this._IDMap[related].save();
+				}
+			  }
+			newItem.save();
+		  }
 	}
 }
 

--- a/chrome/content/zotero/xpcom/translation/translate_item.js
+++ b/chrome/content/zotero/xpcom/translation/translate_item.js
@@ -181,7 +181,7 @@ Zotero.Translate.ItemSaver.prototype = {
 					}
 					
 					// handle see also
-					this._handleRelated(jsonItem, item);
+					this._handleRelated(jsonItem, item, items);
 				}
 				
 				// Add to new item list
@@ -983,21 +983,24 @@ Zotero.Translate.ItemSaver.prototype = {
 		return newTags;
 	},
 	
-	"_handleRelated":function(item, newItem) {
+	"_handleRelated":function(item, newItem, items) {
 		// add to ID map
 		if (item.itemID || item.id) {
-			this._IDMap[item.itemID || item.id] = newItem;
+			this._IDMap[item.itemID || item.id] = newItem.id;
 		  }
 
-		  // add see alsos
-		  if(item.seeAlso) {
-			for(related in item.seeAlso) {
-			  if(this._IDMap[related]) {
-				newItem.addRelatedItem(this._IDMap[related]);
-				this._IDMap[related].addRelatedItem(newItem);
-				this._IDMap[related].save();
+		// add see alsos
+		if (item.seeAlso) {
+			for (let related in item.seeAlso) {
+				Zotero.debug(item.seeAlso[related]);
+				for (let id in this._IDMap) {
+					if (id == item.seeAlso[related]) {
+						newItem.addRelatedItem(items[id]);
+						items[id].addRelatedItem(newItem);
+						items[id].save();
+					}
 				}
-			  }
+			}
 			newItem.save();
 		  }
 	}


### PR DESCRIPTION
Rewrote commented-out code and fixed it so that seeAlso array item get related in Zotero when saved.

Also I'm really sorry about all of the pull requests. I accidentally renamed a branch and everything broke. I had to delete my forked repository and start again.